### PR TITLE
시청자 화면 수정, 스트리밍 종료시 릴리즈 api 호출

### DIFF
--- a/lib/src/api/process_service.dart
+++ b/lib/src/api/process_service.dart
@@ -37,5 +37,16 @@ class ProcessService {
       return false;
     }
   }
+
+  // 프로세스 릴리즈하기
+  Future<bool?> releaseProcess(int processId) async {
+    Map<String, dynamic> data = await _httpClient.getRequest('/release/$processId');
+
+    if (data['result'] == 'true') {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }
 

--- a/lib/src/provider/process_provider.dart
+++ b/lib/src/provider/process_provider.dart
@@ -26,4 +26,9 @@ class ProcessProvider with ChangeNotifier {
     bool? result = await _processService.startMosaic(processId);
     return result;
   }
+
+  Future<bool?> releaseProcess(int processId) async {
+    bool? result = await _processService.releaseProcess(processId);
+    return result;
+  }
 }

--- a/lib/src/view/home.dart
+++ b/lib/src/view/home.dart
@@ -48,7 +48,8 @@ class Home extends StatelessWidget {
         ProcessModel? process = await Provider.of<ProcessProvider>(_context!, listen: false).getNewProcess();
         // ignore: use_build_context_synchronously
         Navigator.push(_context!,
-          MaterialPageRoute(builder: (BuildContext context) => StreamerView(processId: process!.id!)));
+          MaterialPageRoute(builder: (BuildContext context) => StreamerView(processId: process!.id!)))
+          .then((_) => Provider.of<ProcessProvider>(_context!, listen: false).fetchProcessList());
       },
       child: Container(
         color: greyNavy,
@@ -89,7 +90,8 @@ class ProcessListSection extends StatelessWidget {
         return GestureDetector(
           onTap: () {
             Navigator.push(context,
-              MaterialPageRoute(builder: (context) => StreamingView(processId: processId)));
+              MaterialPageRoute(builder: (context) => StreamingView(processId: processId)))
+              .then((_) => Provider.of<ProcessProvider>(context, listen: false).fetchProcessList());
           },
           child: Container(
             padding: const EdgeInsets.all(30),

--- a/lib/src/view/home.dart
+++ b/lib/src/view/home.dart
@@ -92,6 +92,8 @@ class ProcessListSection extends StatelessWidget {
             Navigator.push(context,
               MaterialPageRoute(builder: (context) => StreamingView(processId: processId)))
               .then((_) => Provider.of<ProcessProvider>(context, listen: false).fetchProcessList());
+              // if(needRefresh) {
+              // Provider.of<ProcessProvider>(context, listen: false).fetchProcessList();
           },
           child: Container(
             padding: const EdgeInsets.all(30),

--- a/lib/src/view/streamer_settings_view.dart
+++ b/lib/src/view/streamer_settings_view.dart
@@ -197,46 +197,7 @@ class _StreamerSettingsViewState extends State<StreamerSettingsView> {
                     },
                   ),
                 ],
-              ),
-              // SettingsSection(
-              //   title: const Text('Endpoint'),
-              //   tiles: [
-              //     SettingsTile(
-              //         title: const Text('RTMP endpoint'),
-              //         value: Text(widget.params.rtmpUrl),
-              //         onPressed: (BuildContext context) {
-              //           showDialog(
-              //               context: context,
-              //               builder: (context) {
-              //                 return EditTextScreen(
-              //                     title: "Enter RTMP endpoint URL",
-              //                     initialValue: widget.params.rtmpUrl,
-              //                     onChanged: (value) {
-              //                       setState(() {
-              //                         widget.params.rtmpUrl = value;
-              //                       });
-              //                     });
-              //               });
-              //         }),
-              //     SettingsTile(
-              //         title: const Text('Stream key'),
-              //         value: Text(widget.params.streamKey),
-              //         onPressed: (BuildContext context) {
-              //           showDialog(
-              //               context: context,
-              //               builder: (context) {
-              //                 return EditTextScreen(
-              //                     title: "Enter stream key",
-              //                     initialValue: widget.params.streamKey,
-              //                     onChanged: (value) {
-              //                       setState(() {
-              //                         widget.params.streamKey = value;
-              //                       });
-              //                     });
-              //               });
-              //         }),
-              //   ],
-              // )
+              )
             ],
           )),
     );

--- a/lib/src/view/streamer_view.dart
+++ b/lib/src/view/streamer_view.dart
@@ -104,7 +104,7 @@ class _StreamerViewState extends State<StreamerView> with WidgetsBindingObserver
           padding: const EdgeInsets.only(left: 14),
           child: GestureDetector(
               onTap: () {
-                  Navigator.pop(context);
+                _showEndingConfirmDialog();
               },
               child: const Icon(Icons.arrow_back, color: greyNavy)),
     );
@@ -165,7 +165,7 @@ class _StreamerViewState extends State<StreamerView> with WidgetsBindingObserver
             color: black,
             onPressed:
                 liveStreamController.isStreaming
-                    ? onStopStreamingButtonPressed
+                    ? _showEndingConfirmDialog
                     : null,
           ),
         ],
@@ -225,7 +225,6 @@ class _StreamerViewState extends State<StreamerView> with WidgetsBindingObserver
       await liveStreamController.startStreaming(
         streamKey: streamKey, url: rtmpUrl
       );
-      // Provider.of<ProcessProvider>(_context!, listen: false).startMosaic(processId);
     } catch (error) {
       if (error is PlatformException) {
         debugPrint("Error: failed to start stream: ${error.message}");
@@ -275,7 +274,6 @@ class _StreamerViewState extends State<StreamerView> with WidgetsBindingObserver
     startStreaming().then((_) {
       if (mounted) {
         setState(() {
-          debugPrint("스타트 모자이크");
           Provider.of<ProcessProvider>(_context!, listen: false).startMosaic(processId);
         });
       }
@@ -285,7 +283,9 @@ class _StreamerViewState extends State<StreamerView> with WidgetsBindingObserver
   void onStopStreamingButtonPressed() {
     stopStreaming().then((_) {
       if (mounted) {
-        setState(() {});
+        setState(() {
+          Provider.of<ProcessProvider>(_context!, listen: false).releaseProcess(processId);
+        });
       }
     });
   }
@@ -310,5 +310,30 @@ class _StreamerViewState extends State<StreamerView> with WidgetsBindingObserver
     // ignore: deprecated_member_use
     _scaffoldKey.currentState?.showSnackBar(SnackBar(content: Text(message)));
   }
+
+  _showEndingConfirmDialog() {
+    return showDialog(
+      context: _context!,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          content: const R14Text(text: "스트리밍을 종료하시겠습니까?"),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const R14Text(text: "아니요", textColor: Colors.black12),
+            ),
+            TextButton(
+              onPressed: () { 
+                onStopStreamingButtonPressed();
+                Navigator.of(context).pop();
+                Navigator.of(context).pop();
+              },
+              child: const R14Text(text: "네, 종료할게요!", textColor: Colors.blue),
+            ),
+          ],
+        );
+      }
+    );
   }
+}
   

--- a/lib/src/view/streaming_view.dart
+++ b/lib/src/view/streaming_view.dart
@@ -20,6 +20,7 @@ class _StreamingViewState extends State<StreamingView> {
   late BuildContext? _context;
 
   bool _isLoading = true;
+  bool _isTimerOn = true;
   Timer? timer;
 
   @override
@@ -37,7 +38,8 @@ class _StreamingViewState extends State<StreamingView> {
   void _checkLoading() async {
     if(!_isLoading) {
       debugPrint("isLoading false so stop timer()");
-      // timer!.cancel();
+      // timer!.cancel(); // 화면 멈춤 오류
+      _isTimerOn = false;
     }
 
     debugPrint("_checkLoading()");
@@ -53,6 +55,11 @@ class _StreamingViewState extends State<StreamingView> {
         if(isPlaying!) _isLoading = false;  
         // timer?.cancel();
       });
+    }
+
+    if(_vlcPlayerController.value.isEnded) {
+      debugPrint("isEnded");
+      _showWarningDialog();
     }
   }
 
@@ -78,7 +85,7 @@ class _StreamingViewState extends State<StreamingView> {
 
   @override
   void dispose() {
-    timer?.cancel();
+    if(_isTimerOn) timer?.cancel();
     _vlcPlayerController.dispose();
     super.dispose();
   }
@@ -93,13 +100,7 @@ class _StreamingViewState extends State<StreamingView> {
 
     return Scaffold(
       appBar: AppBar(
-        title: GestureDetector(
-          onTap: (() async { 
-            // debugPrint(_vlcPlayerController.value.isInitialized.toString());
-            bool? isPlaying = await _vlcPlayerController.isPlaying();
-            debugPrint(isPlaying.toString());
-          }),
-          child: Text("Stream ID: ${widget.processId}", style: styleBGreyNavy)),
+        title: Text("Stream ID: ${widget.processId}", style: styleBGreyNavy),
         backgroundColor: white,
         leading: _arrowBackLeadingIcon()
       ),
@@ -126,12 +127,12 @@ class _StreamingViewState extends State<StreamingView> {
 
   Widget _arrowBackLeadingIcon() {
     return Padding(
-          padding: const EdgeInsets.only(left: 14),
-          child: GestureDetector(
-              onTap: () {
-                  Navigator.pop(context);
-              },
-              child: const Icon(Icons.arrow_back, color: greyNavy)),
+      padding: const EdgeInsets.only(left: 14),
+      child: GestureDetector(
+          onTap: () {
+              Navigator.pop(context);
+          },
+          child: const Icon(Icons.arrow_back, color: greyNavy)),
     );
   }
 }

--- a/lib/src/view/streaming_view.dart
+++ b/lib/src/view/streaming_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_vlc_player/flutter_vlc_player.dart';
-import 'package:mosainfo_mobile_app/src/api/http_client.dart';
 import 'package:mosainfo_mobile_app/src/constants/colors.dart';
 import 'package:mosainfo_mobile_app/src/view/text_style.dart';
 
@@ -16,13 +15,35 @@ class StreamingView extends StatefulWidget {
 class _StreamingViewState extends State<StreamingView> {
   late VlcPlayerController _vlcViewController;
 
+  bool isStarted = true;
+
   @override
   void initState() {
     _vlcViewController = VlcPlayerController.network(
-      "${HttpClient.rtmpUrl}/live-out/${widget.processId}",
+      // "${HttpClient.rtmpUrl}/live-out/${widget.processId}",
+      "rtmp://43.201.75.227/live/${widget.processId}",
       autoPlay: true,
+      options: VlcPlayerOptions()
+      // onInit:() { 
+      //   setState(() {
+      //     isStarted = true;
+      //   });
+      // }
     );
+
     super.initState();
+  }
+
+  _vlcInitListener() {
+    setState(() {
+          isStarted = true;
+        });
+  }
+
+  @override
+  void dispose() {
+    _vlcViewController.dispose();
+    super.dispose();
   }
   
   @override
@@ -31,26 +52,67 @@ class _StreamingViewState extends State<StreamingView> {
     final screenWidth = screenSize.width;
     final screenHeight = screenSize.height;
 
+    
+
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Stream ID: ${widget.processId}", style: styleBGreyNavy),
-        backgroundColor: white,
-        leading: _arrowBackLeadingIcon()
-      ),
-      body: Center(
-        child: SizedBox(
-          width: screenWidth, height: screenHeight,
-          child: VlcPlayer(
-            controller: _vlcViewController, 
-            aspectRatio: screenWidth / screenHeight,
-            placeholder: Container(
-              width: 200,
-              height: 200,
-              color: Colors.red,
-              child: const Text("Please Wait:)")),),
-        )
-      )
-    );
+              appBar: AppBar(
+                title: Text("Stream ID: ${widget.processId}", style: styleBGreyNavy),
+                backgroundColor: white,
+                leading: _arrowBackLeadingIcon()
+              ),
+              body: Center(
+                child: Container(
+                  color: white,
+                  width: screenWidth, height: screenHeight,
+                  child: _vlcViewController.value == VlcPlayerValue.uninitialized()
+                  ? const Center(child: CircularProgressIndicator())
+                  : VlcPlayer(
+                    controller: _vlcViewController, 
+                    aspectRatio: screenWidth / screenHeight,
+                    placeholder: const Center(child: Text("Please Wait")))
+                )
+              )
+            );    
+
+    // return FutureBuilder<bool?>(
+    //   future: _vlcViewController.isPlaying(),
+    //   builder: (context, snapshot) {
+    //     if(snapshot.hasData) {
+    //       bool isPlaying = snapshot.data!;
+    //       return Scaffold(
+    //           appBar: AppBar(
+    //             title: Text("Stream ID: ${widget.processId}", style: styleBGreyNavy),
+    //             backgroundColor: white,
+    //             leading: _arrowBackLeadingIcon()
+    //           ),
+    //           body: Center(
+    //             child: Container(
+    //               color: white,
+    //               width: screenWidth, height: screenHeight,
+    //               child: isPlaying
+    //               ? VlcPlayer(
+    //                 controller: _vlcViewController, 
+    //                 aspectRatio: screenWidth / screenHeight,
+    //                 placeholder: const Center(child: CircularProgressIndicator()))
+    //               : const Center(child: CircularProgressIndicator())
+    //             )
+    //           )
+    //         );    
+    //     } else {
+    //       return Scaffold(
+    //           appBar: AppBar(
+    //             title: Text("Stream ID: ${widget.processId}", style: styleBGreyNavy),
+    //             backgroundColor: white,
+    //             leading: _arrowBackLeadingIcon()
+    //           ),
+    //           body: const Center(
+    //             child: Center(child: CircularProgressIndicator())
+    //           )
+    //         );    
+    //     }
+    //   },
+    // );
+    
   }
 
   Widget _arrowBackLeadingIcon() {


### PR DESCRIPTION
시청자 화면에서 로딩시 동글뱅이 인디케이터를 나오게하고 스트리밍 멈추면 스트리밍 종료됐다고 confirm dialog를 띄우도록 했는데 문제가 좀 있습니다.. 
처음 시청자가 화면 들어가면 타이머가 시작되고 3초마다 타이머를 부르면서 화면이 나오는지 안나오는지 확인하는데(이것도 더 좋은 아이디어 있으면 꼭 알려주세요...), 화면이 로딩되면 이 타이머를 종료시키도록 했더니 화면이 멈추네요...ㅠㅜ 에러가 나는 듯 하는데 이유를 모르겠네요 ㅜㅜ 다음 이슈의 에러가 나올 때도, 나오지 않을 때도 있습니다.
- 참고 #9 

일단 스트리밍 종료시 프로세스 릴리즈api 호출해서 릴리즈 되는 건 문제없이 확인했습니다.

그리고 타이머를 종료시키지 않고 계속 사용했을 때 시청자 입장에서 스트리밍 종료도 체크해보게 했는데, 스트리밍이 종료되면 Dialog가 나와야 하는데 저 혼자서 테스트를 할 수가 없어 테스트를 하지 못했습니다 ㅠㅠ 회의때 테스트 방식에 관해서도 논의해보면 좋을 것 같습니다!
